### PR TITLE
Add access policy for Key Vault

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -19,3 +19,13 @@ resource "azurerm_role_assignment" "consul_kvso" {
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = azurerm_user_assigned_identity.consul_iam.principal_id
 }
+
+resource "azurerm_key_vault_access_policy" "kv_reader" {
+  key_vault_id = var.consul_secrets.azure_keyvault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.consul_iam.principal_id
+
+  secret_permissions = [
+    "Get", "List", "Set"
+  ]
+}


### PR DESCRIPTION
## Description
Added a Key Vault access policy for the managed identity that the Consul cluster leverages in order to read and write secrets. This aligns with all the other Azure HVD modules that include both RBAC and access policy auth for the Key Vault:
[TFE HVD](https://github.com/hashicorp/terraform-azurerm-terraform-enterprise-hvd/blob/main/msi.tf#L29-L37)
[Vault Enterprise HVD](https://github.com/hashicorp/terraform-azurerm-vault-enterprise-hvd/blob/main/iam.tf#L21-L38)
[Boundary Controller HVD](https://github.com/hashicorp/terraform-azurerm-boundary-enterprise-controller-hvd/blob/main/msi.tf#L24-L32)
[Boundary Worker HVD](https://github.com/hashicorp/terraform-azurerm-boundary-enterprise-worker-hvd/blob/main/msi.tf#L28-L39)

## Related issue

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?
- Tested on Azure sandbox account
